### PR TITLE
Ensure full MatchingCache compatibility in MemoryStorage

### DIFF
--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -495,6 +495,8 @@ class MemoryStorage(StorageInterface):
                 self._query_functions[function_entry.function_id] = function_entry
             else:
                 self._functions[function_entry.function_id] = function_entry
+            if function_entry.sample_id not in self._sample_id_to_function_ids:
+                self._sample_id_to_function_ids[function_entry.sample_id] = []
             if function_entry.function_id not in self._sample_id_to_function_ids[function_entry.sample_id]:
                 self._sample_id_to_function_ids[function_entry.sample_id].append(function_entry.function_id)
 

--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -483,10 +483,20 @@ class MemoryStorage(StorageInterface):
         for minhash in minhashes:
             self.addMinHash(minhash)
 
-    def createMatchingCache(self, function_ids: List[int]) -> MatchingCache:
-        # TODO: we might want add a flag to allow/disallow returning self
+    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> Union["MemoryStorage", "MatchingCache"]:
+        if allow_self_return:
+            return self
         cache_data = self._getCacheDataForFunctionIds(function_ids)
         return MatchingCache(cache_data)
+
+    def addFunctionEntriesToCache(self, function_entries: List["FunctionEntry"]) -> None:
+        for function_entry in function_entries:
+            if function_entry.function_id < 0:
+                self._query_functions[function_entry.function_id] = function_entry
+            else:
+                self._functions[function_entry.function_id] = function_entry
+            if function_entry.function_id not in self._sample_id_to_function_ids[function_entry.sample_id]:
+                self._sample_id_to_function_ids[function_entry.sample_id].append(function_entry.function_id)
 
     def _getCacheDataForFunctionIds(self, function_ids: List[int]) -> Dict:
         cache_data = {}
@@ -527,7 +537,7 @@ class MemoryStorage(StorageInterface):
         return deepcopy(list(self._families.keys()))
 
     def isSampleId(self, sample_id: int) -> bool:
-        return sample_id in self._samples or sample_id in self._query_samples
+        return sample_id in self._samples or sample_id in self._query_samples or sample_id in self._sample_id_to_function_ids
 
     def isFunctionId(self, function_id: int) -> bool:
         return function_id in self._functions or function_id in self._query_functions
@@ -599,10 +609,9 @@ class MemoryStorage(StorageInterface):
         return None
 
     def getFunctionIdsBySampleId(self, sample_id: int) -> Optional[List["int"]]:
-        function_ids = None
-        if sample_id in self._samples or sample_id in self._query_samples:
-            function_ids = self._sample_id_to_function_ids[sample_id]
-        return function_ids
+        if sample_id in self._sample_id_to_function_ids:
+            return self._sample_id_to_function_ids[sample_id]
+        return None
 
     def getFunctions(self, start_index: int, limit: int) -> Optional["FunctionEntry"]:
         index = 0
@@ -677,6 +686,9 @@ class MemoryStorage(StorageInterface):
     def getMinHashByFunctionId(self, function_id: int) -> Optional[bytes]:
         if function_id in self._functions:
             function_entry = self._functions[function_id]
+            return function_entry.minhash
+        if function_id in self._query_functions:
+            function_entry = self._query_functions[function_id]
             return function_entry.minhash
         return None
 

--- a/mcrit/storage/MongoDbStorage.py
+++ b/mcrit/storage/MongoDbStorage.py
@@ -1011,7 +1011,7 @@ class MongoDbStorage(StorageInterface):
         self._encodeFunction(function_dict)
         return function_dict
 
-    def createMatchingCache(self, function_ids: List[int]) -> MatchingCache:
+    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> MatchingCache:
         cache_data = self._getCacheDataForFunctionIds(function_ids)
         # TODO dont store this as attribute
         self._matching_cache = MatchingCache(cache_data)

--- a/mcrit/storage/StorageInterface.py
+++ b/mcrit/storage/StorageInterface.py
@@ -367,11 +367,12 @@ class StorageInterface:
 
     # TODO: make a MatchingCacheInterface, or MemoryStorage a subclass of MatchingCache?
     # TODO rename -> get?
-    def createMatchingCache(self, function_ids: List[int]) -> Union["MemoryStorage", "MatchingCache"]:
+    def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> Union["MemoryStorage", "MatchingCache"]:
         """Creates a temporary matching cache, for a list of function_ids
 
         Args:
             function_ids: list of function ids
+            allow_self_return: (optional) if True, allows returning self as cache
 
         Returns:
             a matching cache for the specified list of function ids


### PR DESCRIPTION
Updated `MemoryStorage` to ensure it fully satisfies the `MatchingCache` interface when returned as a cache via the `allow_self_return` flag. This included refining ID checks and function lookup logic.

---
*PR created automatically by Jules for task [6849792798438722787](https://jules.google.com/task/6849792798438722787) started by @r0ny123*