### PR TITLE
Log subprocess output in arrival order

### DIFF
--- a/mcrit/SpawningWorker.py
+++ b/mcrit/SpawningWorker.py
@@ -104,7 +104,7 @@ class SpawningWorker(Worker):
                     if accum is not None:
                         accum.append(decoded_line)
             except Exception:
-                pass
+                LOGGER.exception("Exception in subprocess reader thread")
             finally:
                 pipe.close()
 
@@ -120,9 +120,10 @@ class SpawningWorker(Worker):
         except subprocess.TimeoutExpired:
             LOGGER.error(f"Job {str(job.job_id)} running as child from SpawningWorker timed out during processing.")
             console_handle.kill()
+            console_handle.wait()
 
-        t1.join(timeout=1)
-        t2.join(timeout=1)
+        t1.join()
+        t2.join()
 
         if stdout_lines:
             # Search backwards for result_id in case there are trailing empty lines or other output

--- a/mcrit/SpawningWorker.py
+++ b/mcrit/SpawningWorker.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from itertools import zip_longest
 from multiprocessing import Pool, cpu_count
 import subprocess
+import threading
 from typing import Dict, List, Optional, TYPE_CHECKING, Tuple
 
 import tqdm
@@ -92,24 +93,45 @@ class SpawningWorker(Worker):
         console_handle = subprocess.Popen(["python", "-m", "mcrit", "singlejobworker", "--job_id", str(job.job_id)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # extract result_id from console_output
         result_id = None
-        try:
-            stdout_result, stderr_result = console_handle.communicate(timeout=self._queue_config.QUEUE_SPAWNINGWORKER_CHILDREN_TIMEOUT)
-            stdout_result = stdout_result.strip().decode("utf-8")
-             # TODO: log output from subprocess in the order it arrived
-            # instead of the split to stdout, stderr
-            if stdout_result:
-                LOGGER.info("STDOUT logs from subprocess: %s", stdout_result)
-            if stderr_result:
-                stderr_result = stderr_result.strip().decode("utf-8")
-                LOGGER.info("STDERR logs from subprocess: %s", stderr_result)
+        stdout_lines = []
 
-            last_line = stdout_result.split("\n")[-1]
-            # successful output should be just the result_id in a single line
-            match = re.match("(?P<result_id>[0-9a-fA-F]{24})", last_line)
-            if match:
-                result_id = match.group("result_id")
+        def reader(pipe, label, accum):
+            try:
+                for line in iter(pipe.readline, b''):
+                    decoded_line = line.decode("utf-8", errors="replace").rstrip()
+                    if decoded_line:
+                        LOGGER.info("%s logs from subprocess: %s", label, decoded_line)
+                    if accum is not None:
+                        accum.append(decoded_line)
+            except Exception:
+                pass
+            finally:
+                pipe.close()
+
+        t1 = threading.Thread(target=reader, args=(console_handle.stdout, "STDOUT", stdout_lines))
+        t2 = threading.Thread(target=reader, args=(console_handle.stderr, "STDERR", None))
+        t1.daemon = True
+        t2.daemon = True
+        t1.start()
+        t2.start()
+
+        try:
+            console_handle.wait(timeout=self._queue_config.QUEUE_SPAWNINGWORKER_CHILDREN_TIMEOUT)
         except subprocess.TimeoutExpired:
             LOGGER.error(f"Job {str(job.job_id)} running as child from SpawningWorker timed out during processing.")
+            console_handle.kill()
+
+        t1.join(timeout=1)
+        t2.join(timeout=1)
+
+        if stdout_lines:
+            # Search backwards for result_id in case there are trailing empty lines or other output
+            for line in reversed(stdout_lines):
+                if line.strip():
+                    match = re.match("(?P<result_id>[0-9a-fA-F]{24})", line.strip())
+                    if match:
+                        result_id = match.group("result_id")
+                        break
         return result_id
 
     def _executeJob(self, job):


### PR DESCRIPTION
Modified mcrit/SpawningWorker.py to stream subprocess output line by line as it arrives.
- Replaced `console_handle.communicate()` with a multi-threaded approach.
- Used two daemon threads to read from `stdout` and `stderr` concurrently.
- Logged lines as they arrive with appropriate prefixes.
- Improved `result_id` extraction to handle trailing output or empty lines.
- Ensured the subprocess is killed on timeout.
- Verified the solution with a dedicated script and existing tests.

---
*PR created automatically by Jules for task [284213617403072932](https://jules.google.com/task/284213617403072932) started by @r0ny123*