### PR TITLE
MemoryStorage: always return isolated MatchingCache and validate addFunctionEntriesToCache inputs

### DIFF
--- a/mcrit/storage/MemoryStorage.py
+++ b/mcrit/storage/MemoryStorage.py
@@ -484,17 +484,18 @@ class MemoryStorage(StorageInterface):
             self.addMinHash(minhash)
 
     def createMatchingCache(self, function_ids: List[int], allow_self_return: bool = False) -> Union["MemoryStorage", "MatchingCache"]:
-        if allow_self_return:
-            return self
+        # keep allow_self_return in signature for StorageInterface compatibility,
+        # but always return an isolated cache object.
         cache_data = self._getCacheDataForFunctionIds(function_ids)
         return MatchingCache(cache_data)
 
     def addFunctionEntriesToCache(self, function_entries: List["FunctionEntry"]) -> None:
         for function_entry in function_entries:
-            if function_entry.function_id < 0:
-                self._query_functions[function_entry.function_id] = function_entry
-            else:
-                self._functions[function_entry.function_id] = function_entry
+            if function_entry.function_id >= 0:
+                raise ValueError("addFunctionEntriesToCache only accepts query FunctionEntries with negative function_id")
+            self._query_functions[function_entry.function_id] = function_entry
+            if function_entry.sample_id not in self._sample_id_to_function_ids:
+                self._sample_id_to_function_ids[function_entry.sample_id] = []
             if function_entry.function_id not in self._sample_id_to_function_ids[function_entry.sample_id]:
                 self._sample_id_to_function_ids[function_entry.sample_id].append(function_entry.function_id)
 

--- a/tests/testStorage.py
+++ b/tests/testStorage.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from datetime import datetime
+from types import SimpleNamespace
 from unittest import TestCase, main
 
 import pymongo
@@ -301,6 +302,13 @@ class MemoryStorageTest(TestCase):
         cache = self.storage.createMatchingCache([])
         self.assertTrue(hasattr(cache, "getMinHashByFunctionId"))
         self.assertTrue(hasattr(cache, "getSampleIdByFunctionId"))
+        self.assertIsNot(cache, self.storage)
+        self.assertTrue(hasattr(cache, "addFunctionEntriesToCache"))
+
+    def testAddFunctionEntriesToCacheRejectsNonQueryFunctionIds(self):
+        function_entry = SimpleNamespace(function_id=1, sample_id=1, minhash=b"")
+        with self.assertRaises(ValueError):
+            self.storage.addFunctionEntriesToCache([function_entry])
 
 
 ### Added mongo attribute


### PR DESCRIPTION
### Motivation
- Ensure matching caches are isolated from the main `MemoryStorage` instance to avoid accidental shared-state and maintain `StorageInterface` compatibility.
- Enforce that `addFunctionEntriesToCache` only accepts query `FunctionEntry` objects (negative `function_id`) to prevent polluting main storage with non-query entries.

### Description
- Change `createMatchingCache` to always build and return a `MatchingCache` from cache data instead of returning `self`, while keeping the `allow_self_return` parameter in the signature for compatibility.
- Tighten `addFunctionEntriesToCache` to raise `ValueError` when a `FunctionEntry` has a non-negative `function_id`, and always insert query entries into `_query_functions` while updating `_sample_id_to_function_ids` mapping. 
- Minor newline/EOL fix at end of `MemoryStorage.py`.
- Update `tests/testStorage.py` to assert that `createMatchingCache` returns an isolated cache and to add a test `testAddFunctionEntriesToCacheRejectsNonQueryFunctionIds` that verifies a `ValueError` is raised for non-query `FunctionEntry` objects.

### Testing
- Ran the unit tests in `tests/testStorage.py`, including `testMatchingCache` and the new `testAddFunctionEntriesToCacheRejectsNonQueryFunctionIds`, and they passed. 
- Existing MinHash-related tests in `MemoryStorageTest` were exercised and continued to succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37c485958832383a246a756588733)